### PR TITLE
Angular 11 - HMR plugin disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HMR Tests
 
-## Branch `hmr-plugin-11` - Angular 11 - HMR plugin
+## Branch `hmr-plugin-11-bis` - Angular 11 - disabled HMR plugin
 
 * `npm i`
 * `npm run start`
@@ -8,5 +8,5 @@
 * click the button
 * the value changes from 'initial' to 'changed'
 * change anything in one of the files, for example add a color to the `.value` class in `app.component.css`
-* the page is reloaded, but blank
-* the error "[HMR] Update failed: Error: Injector has already been destroyed." is visible in the console
+* the page is reloaded, but the value is back to 'initial'
+* the error in the console is gone

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,10 +10,4 @@ if (environment.production) {
 
 const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
 
-if (environment.hmr) {
-  import('@ngxs/hmr-plugin').then(plugin => {
-    plugin.hmr(module, bootstrap).catch((err: Error) => console.error(err));
-  });
-} else {
-  bootstrap().catch((err: Error) => console.log(err));
-}
+bootstrap().catch((err: Error) => console.log(err));


### PR DESCRIPTION
* `npm i`
* `npm run start`
* open `localhost:4200`
* click the button
* the value changes from 'initial' to 'changed'
* change anything in one of the files, for example add a color to the `.value` class in `app.component.css`
* the page is reloaded, but the value is back to 'initial'
* the error in the console is gone